### PR TITLE
FEAT: Automatic site and PDF publication

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -1,0 +1,108 @@
+# Sample workflow for building and deploying a Jekyll site to GitHub Pages
+name: Deploy Jekyll with GitHub Pages dependencies preinstalled
+
+on:
+  # Runs on pushes targeting the default branch
+  release:
+    types: [published]
+  workflow_dispatch:
+
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - if: github.event.release != null
+        name: set release vars from release event
+        run: |
+          echo "LONG_DATE=${{ github.event.release.published_at }}" >> $GITHUB_ENV
+          echo "LONG_VERSION=${{ github.event.release.tag_name }}" >> $GITHUB_ENV
+      - if: github.event.release == null
+        name: Get previous release
+        id: previousrelease
+        uses: InsonusK/get-latest-release@v1.0.1
+        with:
+          myToken: ${{ github.token }}
+          exclude_types: draft|prerelease
+          view_top: 1
+      - if: github.event.release == null
+        name: set release vars from previous release
+        run: |
+          echo "LONG_DATE=${{ steps.previousrelease.outputs.created_at }}" >> $GITHUB_ENV
+          echo "LONG_VERSION=${{ steps.previousrelease.outputs.tag_name }}" >> $GITHUB_ENV
+      - name: Cut release date
+        uses: bhowell2/github-substring-action@1.0.2
+        id: cut_release_date
+        with:
+          value: ${{ env.LONG_DATE }}
+          length_from_start: 10
+      - name: Cut release versopm
+        uses: bhowell2/github-substring-action@1.0.2
+        id: cut_release_version
+        with:
+          value: ${{ env.LONG_VERSION }}
+          index_of_str: "v"
+      - name: Substitute env vars in files
+        uses: chris-peterson/virgo@v1
+        env:
+          RELEASE_DATE: ${{ steps.cut_release_date.outputs.substring }}
+          RELEASE_VERSION: ${{ steps.cut_release_version.outputs.substring }}
+        with:
+          templates: "specification/metadata.md"
+      - name: Build the spec-publisher project & produce site artifacts
+        run: |
+          cd spec-publisher
+          mvn clean package
+          java -jar target/mets-profile-proc.jar ../profile/E-ARK-CSIP.xml
+      - name: Run Docker job for site publication
+        run: |
+          docker run --rm -v "$PWD:/source" --entrypoint /source/create-site.sh eark4all/spec-pdf-publisher
+          ls -alh ./docs
+      - name: Build the spec-publisher project & produce PDF artifacts
+        run: |
+          git clone --branch feat/pdf-publication https://github.com/DILCISBoard/spec-publisher.git pdf-publisher
+          cd pdf-publisher
+          mvn clean package
+          java -jar target/mets-profile-proc.jar ../profile/E-ARK-CSIP.xml
+      - name: Run Docker job for PDF publication
+        run: |
+          docker run --rm -v "$PWD:/source" --entrypoint /source/create-pdf.sh eark4all/spec-pdf-publisher
+          ls -alh ./docs
+          ls -alh ./docs/pdf
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+      - name: Build with Jekyll docker box
+        run: |
+          mkdir _site
+          docker run --rm -v "$PWD"/docs:/usr/src/app -v "$PWD"/_site:/_site starefossen/github-pages jekyll build -d /_site
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -66,21 +66,10 @@ jobs:
           RELEASE_VERSION: ${{ steps.cut_release_version.outputs.substring }}
         with:
           templates: "specification/metadata.md"
-      - name: Build the spec-publisher project & produce site artifacts
-        run: |
-          cd spec-publisher
-          mvn clean package
-          java -jar target/mets-profile-proc.jar ../profile/E-ARK-CSIP.xml
       - name: Run Docker job for site publication
         run: |
           docker run --rm -v "$PWD:/source" --entrypoint /source/create-site.sh eark4all/spec-pdf-publisher
           ls -alh ./docs
-      - name: Build the spec-publisher project & produce PDF artifacts
-        run: |
-          git clone --branch feat/pdf-publication https://github.com/DILCISBoard/spec-publisher.git pdf-publisher
-          cd pdf-publisher
-          mvn clean package
-          java -jar target/mets-profile-proc.jar ../profile/E-ARK-CSIP.xml
       - name: Run Docker job for PDF publication
         run: |
           docker run --rm -v "$PWD:/source" --entrypoint /source/create-pdf.sh eark4all/spec-pdf-publisher

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "spec-publisher"]
+	path = spec-publisher
+	url = https://github.com/DILCISBoard/spec-publisher.git

--- a/BASE.md
+++ b/BASE.md
@@ -1,0 +1,2 @@
+
+!INCLUDE "specification/CITS_Geospatial_v3.md"

--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-citsgeospatial.dilcis.eu

--- a/PDF.md
+++ b/PDF.md
@@ -1,0 +1,4 @@
+
+!INCLUDE "specification/metadata.md"
+
+!INCLUDE "BASE.md"

--- a/SITE.md
+++ b/SITE.md
@@ -1,0 +1,18 @@
+!INCLUDE "specification/metadata.md"
+
+{{ page.subtitle }}
+================
+
+!INCLUDE "spec-publisher/res/md/common-intro.md"
+
+{{ page.title }}
+================
+
+{{ page.subtitle }}
+-------------------
+
+Version: {{ page.version }}
+
+Date: {{ page.date }}
+
+!INCLUDE "/tmp/site.md"

--- a/SITE_BASE.md
+++ b/SITE_BASE.md
@@ -1,0 +1,4 @@
+
+!TOC
+
+!INCLUDE "BASE.md"

--- a/create-pdf.sh
+++ b/create-pdf.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+echo "Generating PDF document from markdown"
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd "$SCRIPT_DIR" || exit
+
+echo "Generating PDF from markdown"
+bash "$SCRIPT_DIR/spec-publisher/utils/create-venv.sh"
+
+
+if [ ! -d "$SCRIPT_DIR/docs/pdf" ]
+then
+  echo " - creating docs/pdf directory"
+  mkdir -p "$SCRIPT_DIR/docs/pdf/"
+fi
+
+command -v markdown-pp >/dev/null 2>&1 || {
+  tmpdir=$(dirname "$(mktemp -u)")
+  # shellcheck source=/tmp/.venv-markdown/bin/activate
+  source "$tmpdir/.venv-markdown/bin/activate"
+}
+
+echo " - MARKDOWN-PP: Preparing PDF markdown"
+markdown-pp PDF.md -o docs/eark-cits-geospatial-pdf.md -e tableofcontents
+sed -i 's%fig_2_csip_scope.svg%fig_2_csip_scope.png%' docs/eark-cits-geospatial-pdf.md
+
+cp -Rf specification/media docs/
+cp -Rf spec-publisher/res/md/figs docs/
+
+cd docs || exit
+
+echo " - PANDOC: Generating Preface from markdown"
+pandoc  --from gfm \
+        --to latex \
+        --metadata-file "../spec-publisher/pandoc/metadata.yaml" \
+        "../spec-publisher/res/md/common-intro.md" \
+        -o "./preface.tex"
+sed -i 's%section{%section*{%' ./preface.tex
+
+echo " - PANDOC: Generating PDF document from markdown and Tex sources"
+pandoc  --from markdown \
+        --template ../spec-publisher/pandoc/templates/eisvogel.latex \
+        --listings \
+        --table-of-contents \
+        --metadata-file "../spec-publisher/pandoc/metadata.yaml" \
+        --include-before-body "./preface.tex" \
+        --number-sections \
+        eark-cits-geospatial-pdf.md \
+        -o "./pdf/eark-cits-geospatial.pdf"
+
+rm eark-cits-geospatial-pdf.md preface.tex
+
+echo " - Finished"

--- a/create-site.sh
+++ b/create-site.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+echo "Generating GitHub pages site from markdown"
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd "$SCRIPT_DIR" || exit
+
+if [ ! -d ./docs ]
+then
+  echo " - creating docs directory"
+  mkdir ./docs
+fi
+
+if [ -d ./docs/figs ]
+then
+  echo " - removing existing figs directory"
+  rm -rf ./docs/figs
+fi
+
+if [ -d ./docs/pdf ]
+then
+  echo " - removing existing pdf directory"
+  rm -rf ./docs/pdf]
+fi
+
+if [ -d ./docs/profile ]
+then
+  echo " - removing existing profile directory"
+  rm -rf ./docs/profile
+fi
+
+if [ -d ./docs/schema ]
+then
+  echo " - removing existing schema directory"
+  rm -rf ./docs/schema
+fi
+
+if [ -d ./docs/archive ]
+then
+  echo " - removing existing archive directory"
+  rm -rf ./docs/archive
+fi
+
+if [ -d ./docs/_data ]
+then
+  echo " - removing existing menu data"
+  rm -rf ./docs/_data
+fi
+
+if [ -d ./docs/_includes ]
+then
+  echo " - removing existing includes"
+  rm -rf ./docs/_includes
+fi
+
+if [ -d ./docs/_layouts ]
+then
+  echo " - removing existing layouts"
+  rm -rf ./docs/_layouts
+fi
+
+if [ -d ./docs/img ]
+then
+  echo " - removing existing images"
+  rm -rf ./docs/img
+fi
+
+if [ -d ./docs/css ]
+then
+  echo " - removing existing css"
+  rm -rf ./docs/css
+fi
+
+if [ -d ./docs/release-notes ]
+then
+  echo " - removing existing release notes"
+  rm -rf ./docs/release-notes
+fi
+mkdir ./docs/release-notes
+
+bash "$SCRIPT_DIR/spec-publisher/utils/create-venv.sh"
+
+command -v markdown-pp >/dev/null 2>&1 || {
+  tmpdir=$(dirname "$(mktemp -u)")
+  source "$tmpdir/.venv-markdown/bin/activate"
+}
+
+echo " - MARKDOWN-PP: generating temp-site"
+markdown-pp SITE_BASE.md -o /tmp/site.md
+echo " - MARKDOWN-PP: generating site index.md"
+markdown-pp SITE.md -o ./docs/index.md
+
+echo " - copying files to docs directory"
+cp -Rf specification/media docs/
+cp -Rf spec-publisher/res/md/figs docs/
+cp -Rf spec-publisher/site/* docs/
+# Copy remaining collaterel
+cp -Rf profile docs/
+cp -Rf archived docs/archive

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gem 'github-pages', group: :jekyll_plugins

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,14 @@
+github: [metadata]
+encoding: UTF-8
+kramdown:
+  input: GFM
+  hard_wrap: false
+future: true
+jailed: false
+gfm_quirks: paragraph_end
+repository: DILCISBoard/CITS-Geospatial
+plugins:
+- jekyll-github-metadata
+- jekyll-redirect-from
+- jekyll-sitemap
+- jemoji

--- a/specification/CITS_Geospatial_v3.md
+++ b/specification/CITS_Geospatial_v3.md
@@ -1,13 +1,3 @@
-**Specification for the E-ARK Content Information Type Specification for
-digital geospatial data records archiving (CITS Geospatial)**
-
-*[A proper front page will be created for the publication occurring
-after implementation of review comments.]*
-
-# Preface
-
-*To be added from Common Preface https://github.com/DILCISBoard/spec-publisher/blob/master/res/md/common-intro.md*
-
 
 # Context
 

--- a/specification/metadata.md
+++ b/specification/metadata.md
@@ -1,0 +1,13 @@
+---
+title: E-ARK CITS Geospatial
+subtitle: E-ARK Content Information Type Specification for digital geospatial data records archiving
+abstract: |
+        The purpose of this document is to describe the Content Information Type
+        Specification for Geospatial records (CITS Geospatial). This
+        specification describes how to package files containing geospatial
+        records in a CSIP package(s) and the extension of the E-ARK SIP. It is
+        designed to be used for the transfer of different types of Geospatial
+        records and resources to and from archives.
+version: ${RELEASE_VERSION}
+date: ${RELEASE_DATE}
+---


### PR DESCRIPTION
- added GitHub Actions publication workflow script to `.github/workflows/jekyll-gh-pages.yml`;
- added `spec-publisher` project as a git submodule;
- using basic Markdown templates added as `BASE.md`, `SITE_BASE.md`, `SITE.md` and `PDF.md`;
- added docker scripts for automatic publication of the site and PDF, `create-site.sh` and `create-pdf.sh`;
- added `./docs/Gemfile` and `docs/_config.yml` to support GitHub Pages publication;
- removed unnecessary intro to the markdown source `specification/CITS_Geospatial_v3.md`;
- added publication metadata file `specification/metadata.md`; and
- removed old `CNAME` which isn't needed for GitHub Workflow publication.